### PR TITLE
Fix "navigator is undefined" on server when there is a request without userAgent

### DIFF
--- a/src/sniffr.js
+++ b/src/sniffr.js
@@ -54,6 +54,7 @@
   };
 
   var UNKNOWN = "Unknown";
+  var isBrowser = typeof window !== 'undefined'
 
   var propertyNames = Object.keys(properties);
 
@@ -101,7 +102,8 @@
 
   Sniffr.prototype.sniff = function(userAgentString) {
     var self = this;
-    var userAgent = (userAgentString || navigator.userAgent || "").toLowerCase();
+    var fallbackUserAgent = isBrowser ? navigator.userAgent : ""
+    var userAgent = (userAgentString || fallbackUserAgent).toLowerCase();
 
     propertyNames.forEach(function(propertyName) {
       determineProperty(self, propertyName, userAgent);


### PR DESCRIPTION
We keep having this in our log "ReferenceError: navigator is not defined". I understand some bots don't set their userAgent and this library falls back to navigator.userAgent which isn't on the server