### PR TITLE
Use User-Agent Client Hints API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,30 @@ if (RecognizedBrowser.os.name === "windows"
 }
 ```
 
-For backward compatibility purposes the following more wordy legacy usage pattern is also supported:
+#### Using User-Agent and Client Hints API (Recommended for improved accuracy)
+
+For better accuracy in modern browsers, use the async `sniffHints()` method which leverages the [User-Agent Client Hints API](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API):
+
+```javascript
+import Sniffr from "sniffr"
+
+const sniffr = new Sniffr()
+await sniffr.sniffHints()
+
+//If Windows and Firefox 28 or later
+if (sniffr.os.name === "windows"
+  && sniffr.browser.name === "firefox" && sniffr.browser.version[0] >= 28) {
+  //Apply some workaround
+}
+```
+
+The `sniffHints()` method automatically:
+- Uses User-Agent Client Hints API when available (Chrome, Edge, Opera, Brave, etc.)
+- Gracefully falls back to user agent string parsing for unsupported browsers (Firefox, Safari, etc.)
+- Provides more reliable OS, browser, and device detection
+
+For backward compatibility purposes the old `sniff` method is also supported. This one uses only the user agent string
+and ignored the Client Hints API:
 
 ```javascript
 import Sniffr from "sniffr"
@@ -114,11 +137,44 @@ if (Sniffr.os.name === "windows"
 
 ## API
 
+### `RecognizedBrowser` (module-level exports)
 * `RecognizedBrowser.os`: operating system
 * `RecognizedBrowser.browser`: browser
 * `RecognizedBrowser.device`: device
 
-`Sniffr.sniff` : function that expects a user agent string as an argument, it is called automatically in a browser
+### `Sniffr` class methods
+
+#### `sniff(userAgentString?: string): this`
+Synchronous method that detects browser, OS, and device information using user agent string parsing only.
+
+- **Usage**: Useful for backward compatibility and server-side usage
+- **Parameters**: Optional user agent string. If not provided, uses `navigator.userAgent` in browser
+- **Returns**: `this` (Sniffr instance for chaining)
+- **Supports**: All browsers
+
+Example:
+```javascript
+const sniffr = new Sniffr()
+sniffr.sniff()
+console.log(sniffr.browser.name)
+```
+
+#### `sniffHints(userAgentString?: string): Promise<this>`
+Asynchronous method that uses User-Agent Client Hints API when available for more accurate detection, with automatic fallback to user agent string parsing.
+
+- **Usage**: Recommended for browser environments where accuracy is important
+- **Parameters**: Optional user agent string. If not provided, attempts to fetch UA hints from the browser
+- **Returns**: `Promise<this>` (resolves to Sniffr instance)
+- **Supports**: All browsers (with graceful fallback for unsupported ones)
+- **Privacy**: When UA hints are unavailable or rejected by the browser, falls back to user agent string
+- **Availability**: Automatically detects User-Agent Client Hints API support; no browser checks needed
+
+Example:
+```javascript
+const sniffr = new Sniffr()
+await sniffr.sniffHints()
+console.log(sniffr.browser.name)
+```
 
 ## How to use on the server side
 

--- a/dist/sniffr.d.ts
+++ b/dist/sniffr.d.ts
@@ -12,6 +12,34 @@ export declare enum Browser {
     Yandex = "yandex",
     SeaMonkey = "seamonkey"
 }
+interface UADataValues {
+    architecture?: string;
+    bitness?: string;
+    brands?: Array<{
+        brand: string;
+        version: string;
+    }>;
+    formFactors?: string[];
+    fullVersionList?: Array<{
+        brand: string;
+        version: string;
+    }>;
+    mobile?: boolean;
+    model?: string;
+    platform?: string;
+    platformVersion?: string;
+    wow64?: boolean;
+    [key: string]: any;
+}
+interface NavigatorUAData {
+    brands: Array<{
+        brand: string;
+        version: string;
+    }>;
+    mobile: boolean;
+    platform: string;
+    getHighEntropyValues(hints: string[]): Promise<UADataValues>;
+}
 export declare enum OS {
     Linux = "linux",
     MacOS = "macos",
@@ -47,12 +75,29 @@ export interface RecognizedBrowser {
     browser: RecognizedBrowserProperty<Browser>;
     device: RecognizedBrowserProperty<Device>;
 }
+declare global {
+    interface Navigator {
+        userAgentData?: NavigatorUAData;
+    }
+}
 export default class Sniffr {
     os: RecognizedBrowserProperty<OS>;
     device: RecognizedBrowserProperty<Device>;
     browser: RecognizedBrowserProperty<Browser>;
     constructor();
+    /**
+     * Synchronous sniffing using user agent string only.
+     * Useful for backward compatibility and server-side usage.
+     * For more accurate detection, use sniffHints() if in a browser.
+     */
     sniff(userAgentString?: string): this;
+    /**
+     * Sniffs browser, OS, and device using User-Agent Client Hints API if available,
+     * with fallback to user agent string.
+     * Requires User-Agent Client Hints API support in the browser.
+     * If hints are not available (e.g., Firefox, privacy settings), falls back to user agent string.
+     */
+    sniffHints(userAgentString?: string): Promise<this>;
 }
 export declare const RecognizedBrowser: RecognizedBrowser;
 declare global {
@@ -60,3 +105,4 @@ declare global {
         Sniffr: Sniffr;
     }
 }
+export {};

--- a/dist/sniffr.js
+++ b/dist/sniffr.js
@@ -10,6 +10,42 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.RecognizedBrowser = exports.Device = exports.OS = exports.Browser = void 0;
 var Browser;
@@ -147,6 +183,212 @@ function determineProperty(matchers, userAgent) {
     });
     return recognizedProperty;
 }
+function getUAHintsData() {
+    return __awaiter(this, void 0, void 0, function () {
+        var uaData, hints, error_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (!navigator || !navigator.userAgentData) {
+                        return [2 /*return*/, null];
+                    }
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 3, , 4]);
+                    uaData = navigator.userAgentData;
+                    return [4 /*yield*/, uaData.getHighEntropyValues([
+                            'platform',
+                            'platformVersion',
+                            'architecture',
+                            'model',
+                            'fullVersionList',
+                            'formFactors'
+                        ])];
+                case 2:
+                    hints = _a.sent();
+                    return [2 /*return*/, {
+                            platform: hints.platform,
+                            platformVersion: hints.platformVersion,
+                            mobile: uaData.mobile,
+                            architecture: hints.architecture,
+                            model: hints.model,
+                            brands: uaData.brands,
+                            fullVersionList: hints.fullVersionList,
+                            formFactors: hints.formFactors
+                        }];
+                case 3:
+                    error_1 = _a.sent();
+                    // If high entropy values are rejected or not available, return null
+                    // This preserves privacy and provides a graceful fallback
+                    return [2 /*return*/, null];
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
+}
+function detectBrowserFromHints(hints) {
+    if (!hints.fullVersionList || hints.fullVersionList.length === 0) {
+        return null;
+    }
+    for (var _i = 0, _a = hints.fullVersionList; _i < _a.length; _i++) {
+        var brandInfo = _a[_i];
+        var brand = brandInfo.brand.toLowerCase();
+        var version = brandInfo.version;
+        if (brand.includes('microsoft edge') || brand === 'edg') {
+            return {
+                name: Browser.Edge,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand.includes('chrome') && !brand.includes('chromium')) {
+            return {
+                name: Browser.Chrome,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand === 'chromium') {
+            // Continue to next as chromium is not a specific browser
+            continue;
+        }
+        else if (brand.includes('safari') && !brand.includes('chrome')) {
+            return {
+                name: Browser.Safari,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand.includes('firefox')) {
+            return {
+                name: Browser.Firefox,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand.includes('opera')) {
+            return {
+                name: Browser.Opera,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+    }
+    return null;
+}
+function detectOSFromHints(hints) {
+    if (!hints.platform) {
+        return null;
+    }
+    var platform = hints.platform.toLowerCase();
+    var platformVersion = hints.platformVersion || '';
+    if (platform === 'windows') {
+        return {
+            name: OS.Windows,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'macos') {
+        return {
+            name: OS.MacOS,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'linux') {
+        return {
+            name: OS.Linux,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'android') {
+        return {
+            name: OS.Android,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'ios') {
+        return {
+            name: OS.iOS,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'chromeos') {
+        return {
+            name: OS.ChromeOS,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    return null;
+}
+function detectDeviceFromHints(hints) {
+    var _a, _b;
+    if (hints.formFactors && hints.formFactors.length > 0) {
+        var formFactor = hints.formFactors[0].toLowerCase();
+        if (formFactor === 'tablet') {
+            if (((_a = hints.platform) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === 'ios') {
+                return {
+                    name: Device.iPad,
+                    versionString: 'Unknown',
+                    version: []
+                };
+            }
+        }
+        else if (formFactor === 'mobile') {
+            if (((_b = hints.platform) === null || _b === void 0 ? void 0 : _b.toLowerCase()) === 'ios') {
+                return {
+                    name: Device.iPhone,
+                    versionString: 'Unknown',
+                    version: []
+                };
+            }
+        }
+    }
+    if (hints.model) {
+        var model = hints.model.toLowerCase();
+        if (model.includes('iphone')) {
+            return {
+                name: Device.iPhone,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+        else if (model.includes('ipad')) {
+            return {
+                name: Device.iPad,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+        else if (model.includes('nexus')) {
+            return {
+                name: Device.Nexus,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+        else if (model.includes('galaxy')) {
+            if (model.includes('nexus')) {
+                return {
+                    name: Device.GalaxyNexus,
+                    versionString: 'Unknown',
+                    version: []
+                };
+            }
+            return {
+                name: Device.Galaxy,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+    }
+    return null;
+}
 var isBrowser = typeof window !== 'undefined';
 var Sniffr = /** @class */ (function () {
     function Sniffr() {
@@ -154,6 +396,11 @@ var Sniffr = /** @class */ (function () {
         this.device = UnknownProperty;
         this.browser = UnknownProperty;
     }
+    /**
+     * Synchronous sniffing using user agent string only.
+     * Useful for backward compatibility and server-side usage.
+     * For more accurate detection, use sniffHints() if in a browser.
+     */
     Sniffr.prototype.sniff = function (userAgentString) {
         var fallbackUserAgent = isBrowser ? navigator.userAgent : '';
         var userAgent = (userAgentString || fallbackUserAgent).toLowerCase();
@@ -161,6 +408,45 @@ var Sniffr = /** @class */ (function () {
         this.device = determineProperty(deviceMatchers, userAgent);
         this.browser = determineProperty(browserMatchers, userAgent);
         return this;
+    };
+    /**
+     * Sniffs browser, OS, and device using User-Agent Client Hints API if available,
+     * with fallback to user agent string.
+     * Requires User-Agent Client Hints API support in the browser.
+     * If hints are not available (e.g., Firefox, privacy settings), falls back to user agent string.
+     */
+    Sniffr.prototype.sniffHints = function (userAgentString) {
+        return __awaiter(this, void 0, void 0, function () {
+            var fallbackUserAgent, userAgent, hintsData, browserFromHints, osFromHints, deviceFromHints;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        fallbackUserAgent = isBrowser ? navigator.userAgent : '';
+                        userAgent = (userAgentString || fallbackUserAgent).toLowerCase();
+                        hintsData = null;
+                        if (!(!userAgentString && (isBrowser || (navigator === null || navigator === void 0 ? void 0 : navigator.userAgentData)))) return [3 /*break*/, 2];
+                        return [4 /*yield*/, getUAHintsData()];
+                    case 1:
+                        hintsData = _a.sent();
+                        _a.label = 2;
+                    case 2:
+                        if (hintsData) {
+                            browserFromHints = detectBrowserFromHints(hintsData);
+                            osFromHints = detectOSFromHints(hintsData);
+                            deviceFromHints = detectDeviceFromHints(hintsData);
+                            this.browser = browserFromHints || determineProperty(browserMatchers, userAgent);
+                            this.os = osFromHints || determineProperty(osMatchers, userAgent);
+                            this.device = deviceFromHints || determineProperty(deviceMatchers, userAgent);
+                        }
+                        else {
+                            this.os = determineProperty(osMatchers, userAgent);
+                            this.device = determineProperty(deviceMatchers, userAgent);
+                            this.browser = determineProperty(browserMatchers, userAgent);
+                        }
+                        return [2 /*return*/, this];
+                }
+            });
+        });
     };
     return Sniffr;
 }());
@@ -171,12 +457,21 @@ exports.RecognizedBrowser = {
     device: UnknownProperty
 };
 if (isBrowser) {
-    var result = new Sniffr().sniff(navigator.userAgent);
-    exports.RecognizedBrowser.os = result.os;
-    exports.RecognizedBrowser.device = result.device;
-    exports.RecognizedBrowser.browser = result.browser;
+    var sniffer_1 = new Sniffr();
+    sniffer_1.sniffHints().then(function () {
+        exports.RecognizedBrowser.os = sniffer_1.os;
+        exports.RecognizedBrowser.device = sniffer_1.device;
+        exports.RecognizedBrowser.browser = sniffer_1.browser;
+    }).catch(function () {
+        var fallbackSniffer = new Sniffr().sniff(navigator.userAgent);
+        exports.RecognizedBrowser.os = fallbackSniffer.os;
+        exports.RecognizedBrowser.device = fallbackSniffer.device;
+        exports.RecognizedBrowser.browser = fallbackSniffer.browser;
+    });
 }
 if (isBrowser && typeof module == 'undefined') {
     window.Sniffr = new Sniffr();
-    window.Sniffr.sniff(navigator.userAgent);
+    window.Sniffr.sniffHints().catch(function () {
+        window.Sniffr.sniff(navigator.userAgent);
+    });
 }

--- a/dist/sniffr.standalone.js
+++ b/dist/sniffr.standalone.js
@@ -17,6 +17,42 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.RecognizedBrowser = exports.Device = exports.OS = exports.Browser = void 0;
 var Browser;
@@ -154,6 +190,212 @@ function determineProperty(matchers, userAgent) {
     });
     return recognizedProperty;
 }
+function getUAHintsData() {
+    return __awaiter(this, void 0, void 0, function () {
+        var uaData, hints, error_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (!navigator || !navigator.userAgentData) {
+                        return [2 /*return*/, null];
+                    }
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 3, , 4]);
+                    uaData = navigator.userAgentData;
+                    return [4 /*yield*/, uaData.getHighEntropyValues([
+                            'platform',
+                            'platformVersion',
+                            'architecture',
+                            'model',
+                            'fullVersionList',
+                            'formFactors'
+                        ])];
+                case 2:
+                    hints = _a.sent();
+                    return [2 /*return*/, {
+                            platform: hints.platform,
+                            platformVersion: hints.platformVersion,
+                            mobile: uaData.mobile,
+                            architecture: hints.architecture,
+                            model: hints.model,
+                            brands: uaData.brands,
+                            fullVersionList: hints.fullVersionList,
+                            formFactors: hints.formFactors
+                        }];
+                case 3:
+                    error_1 = _a.sent();
+                    // If high entropy values are rejected or not available, return null
+                    // This preserves privacy and provides a graceful fallback
+                    return [2 /*return*/, null];
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
+}
+function detectBrowserFromHints(hints) {
+    if (!hints.fullVersionList || hints.fullVersionList.length === 0) {
+        return null;
+    }
+    for (var _i = 0, _a = hints.fullVersionList; _i < _a.length; _i++) {
+        var brandInfo = _a[_i];
+        var brand = brandInfo.brand.toLowerCase();
+        var version = brandInfo.version;
+        if (brand.includes('microsoft edge') || brand === 'edg') {
+            return {
+                name: Browser.Edge,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand.includes('chrome') && !brand.includes('chromium')) {
+            return {
+                name: Browser.Chrome,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand === 'chromium') {
+            // Continue to next as chromium is not a specific browser
+            continue;
+        }
+        else if (brand.includes('safari') && !brand.includes('chrome')) {
+            return {
+                name: Browser.Safari,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand.includes('firefox')) {
+            return {
+                name: Browser.Firefox,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+        else if (brand.includes('opera')) {
+            return {
+                name: Browser.Opera,
+                versionString: version,
+                version: parseVersion(version)
+            };
+        }
+    }
+    return null;
+}
+function detectOSFromHints(hints) {
+    if (!hints.platform) {
+        return null;
+    }
+    var platform = hints.platform.toLowerCase();
+    var platformVersion = hints.platformVersion || '';
+    if (platform === 'windows') {
+        return {
+            name: OS.Windows,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'macos') {
+        return {
+            name: OS.MacOS,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'linux') {
+        return {
+            name: OS.Linux,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'android') {
+        return {
+            name: OS.Android,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'ios') {
+        return {
+            name: OS.iOS,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    else if (platform === 'chromeos') {
+        return {
+            name: OS.ChromeOS,
+            versionString: platformVersion || 'Unknown',
+            version: platformVersion ? parseVersion(platformVersion) : []
+        };
+    }
+    return null;
+}
+function detectDeviceFromHints(hints) {
+    var _a, _b;
+    if (hints.formFactors && hints.formFactors.length > 0) {
+        var formFactor = hints.formFactors[0].toLowerCase();
+        if (formFactor === 'tablet') {
+            if (((_a = hints.platform) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === 'ios') {
+                return {
+                    name: Device.iPad,
+                    versionString: 'Unknown',
+                    version: []
+                };
+            }
+        }
+        else if (formFactor === 'mobile') {
+            if (((_b = hints.platform) === null || _b === void 0 ? void 0 : _b.toLowerCase()) === 'ios') {
+                return {
+                    name: Device.iPhone,
+                    versionString: 'Unknown',
+                    version: []
+                };
+            }
+        }
+    }
+    if (hints.model) {
+        var model = hints.model.toLowerCase();
+        if (model.includes('iphone')) {
+            return {
+                name: Device.iPhone,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+        else if (model.includes('ipad')) {
+            return {
+                name: Device.iPad,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+        else if (model.includes('nexus')) {
+            return {
+                name: Device.Nexus,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+        else if (model.includes('galaxy')) {
+            if (model.includes('nexus')) {
+                return {
+                    name: Device.GalaxyNexus,
+                    versionString: 'Unknown',
+                    version: []
+                };
+            }
+            return {
+                name: Device.Galaxy,
+                versionString: 'Unknown',
+                version: []
+            };
+        }
+    }
+    return null;
+}
 var isBrowser = typeof window !== 'undefined';
 var Sniffr = /** @class */ (function () {
     function Sniffr() {
@@ -161,6 +403,11 @@ var Sniffr = /** @class */ (function () {
         this.device = UnknownProperty;
         this.browser = UnknownProperty;
     }
+    /**
+     * Synchronous sniffing using user agent string only.
+     * Useful for backward compatibility and server-side usage.
+     * For more accurate detection, use sniffHints() if in a browser.
+     */
     Sniffr.prototype.sniff = function (userAgentString) {
         var fallbackUserAgent = isBrowser ? navigator.userAgent : '';
         var userAgent = (userAgentString || fallbackUserAgent).toLowerCase();
@@ -168,6 +415,45 @@ var Sniffr = /** @class */ (function () {
         this.device = determineProperty(deviceMatchers, userAgent);
         this.browser = determineProperty(browserMatchers, userAgent);
         return this;
+    };
+    /**
+     * Sniffs browser, OS, and device using User-Agent Client Hints API if available,
+     * with fallback to user agent string.
+     * Requires User-Agent Client Hints API support in the browser.
+     * If hints are not available (e.g., Firefox, privacy settings), falls back to user agent string.
+     */
+    Sniffr.prototype.sniffHints = function (userAgentString) {
+        return __awaiter(this, void 0, void 0, function () {
+            var fallbackUserAgent, userAgent, hintsData, browserFromHints, osFromHints, deviceFromHints;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        fallbackUserAgent = isBrowser ? navigator.userAgent : '';
+                        userAgent = (userAgentString || fallbackUserAgent).toLowerCase();
+                        hintsData = null;
+                        if (!(!userAgentString && (isBrowser || (navigator === null || navigator === void 0 ? void 0 : navigator.userAgentData)))) return [3 /*break*/, 2];
+                        return [4 /*yield*/, getUAHintsData()];
+                    case 1:
+                        hintsData = _a.sent();
+                        _a.label = 2;
+                    case 2:
+                        if (hintsData) {
+                            browserFromHints = detectBrowserFromHints(hintsData);
+                            osFromHints = detectOSFromHints(hintsData);
+                            deviceFromHints = detectDeviceFromHints(hintsData);
+                            this.browser = browserFromHints || determineProperty(browserMatchers, userAgent);
+                            this.os = osFromHints || determineProperty(osMatchers, userAgent);
+                            this.device = deviceFromHints || determineProperty(deviceMatchers, userAgent);
+                        }
+                        else {
+                            this.os = determineProperty(osMatchers, userAgent);
+                            this.device = determineProperty(deviceMatchers, userAgent);
+                            this.browser = determineProperty(browserMatchers, userAgent);
+                        }
+                        return [2 /*return*/, this];
+                }
+            });
+        });
     };
     return Sniffr;
 }());
@@ -178,13 +464,22 @@ exports.RecognizedBrowser = {
     device: UnknownProperty
 };
 if (isBrowser) {
-    var result = new Sniffr().sniff(navigator.userAgent);
-    exports.RecognizedBrowser.os = result.os;
-    exports.RecognizedBrowser.device = result.device;
-    exports.RecognizedBrowser.browser = result.browser;
+    var sniffer_1 = new Sniffr();
+    sniffer_1.sniffHints().then(function () {
+        exports.RecognizedBrowser.os = sniffer_1.os;
+        exports.RecognizedBrowser.device = sniffer_1.device;
+        exports.RecognizedBrowser.browser = sniffer_1.browser;
+    }).catch(function () {
+        var fallbackSniffer = new Sniffr().sniff(navigator.userAgent);
+        exports.RecognizedBrowser.os = fallbackSniffer.os;
+        exports.RecognizedBrowser.device = fallbackSniffer.device;
+        exports.RecognizedBrowser.browser = fallbackSniffer.browser;
+    });
 }
 if (isBrowser && typeof module == 'undefined') {
     window.Sniffr = new Sniffr();
-    window.Sniffr.sniff(navigator.userAgent);
+    window.Sniffr.sniffHints().catch(function () {
+        window.Sniffr.sniff(navigator.userAgent);
+    });
 }
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sniffr",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Browser, os and device detection",
   "main": "dist/sniffr.js",
   "types": "dist/sniffr.d.ts",

--- a/src/sniffr.ts
+++ b/src/sniffr.ts
@@ -13,6 +13,28 @@ export enum Browser {
   SeaMonkey = 'seamonkey'
 }
 
+// Type definitions for the User-Agent Client Hints API
+interface UADataValues {
+  architecture?: string
+  bitness?: string
+  brands?: Array<{ brand: string; version: string }>
+  formFactors?: string[]
+  fullVersionList?: Array<{ brand: string; version: string }>
+  mobile?: boolean
+  model?: string
+  platform?: string
+  platformVersion?: string
+  wow64?: boolean
+  [key: string]: any
+}
+
+interface NavigatorUAData {
+  brands: Array<{ brand: string; version: string }>
+  mobile: boolean
+  platform: string
+  getHighEntropyValues(hints: string[]): Promise<UADataValues>
+}
+
 export enum OS {
   Linux = 'linux',
   MacOS = 'macos',
@@ -118,6 +140,17 @@ export interface RecognizedBrowser {
   device: RecognizedBrowserProperty<Device>
 }
 
+interface UAHintsData {
+  platform?: string
+  platformVersion?: string
+  mobile?: boolean
+  architecture?: string
+  model?: string
+  brands?: Array<{ brand: string; version: string }>
+  fullVersionList?: Array<{ brand: string; version: string }>
+  formFactors?: string[]
+}
+
 function parseVersion(versionString: string) {
   return versionString.split(/[\._]/).map(function(versionPart) {
     return parseInt(versionPart);
@@ -151,6 +184,205 @@ function determineProperty<T>(matchers: [RegExp, T][], userAgent: string): Recog
   return recognizedProperty
 }
 
+declare global {
+  interface Navigator {
+    userAgentData?: NavigatorUAData
+  }
+}
+
+async function getUAHintsData(): Promise<UAHintsData | null> {
+  if (!navigator || !navigator.userAgentData) {
+    return null
+  }
+
+  try {
+    const uaData = navigator.userAgentData
+    const hints = await uaData.getHighEntropyValues([
+      'platform',
+      'platformVersion',
+      'architecture',
+      'model',
+      'fullVersionList',
+      'formFactors'
+    ])
+    
+    return {
+      platform: hints.platform,
+      platformVersion: hints.platformVersion,
+      mobile: uaData.mobile,
+      architecture: hints.architecture,
+      model: hints.model,
+      brands: uaData.brands,
+      fullVersionList: hints.fullVersionList,
+      formFactors: hints.formFactors
+    }
+  } catch (error) {
+    // If high entropy values are rejected or not available, return null
+    // This preserves privacy and provides a graceful fallback
+    return null
+  }
+}
+
+function detectBrowserFromHints(hints: UAHintsData): RecognizedBrowserProperty<Browser> | null {
+  if (!hints.fullVersionList || hints.fullVersionList.length === 0) {
+    return null
+  }
+
+  for (const brandInfo of hints.fullVersionList) {
+    const brand = brandInfo.brand.toLowerCase()
+    const version = brandInfo.version
+
+    if (brand.includes('microsoft edge') || brand === 'edg') {
+      return {
+        name: Browser.Edge,
+        versionString: version,
+        version: parseVersion(version)
+      }
+    } else if (brand.includes('chrome') && !brand.includes('chromium')) {
+      return {
+        name: Browser.Chrome,
+        versionString: version,
+        version: parseVersion(version)
+      }
+    } else if (brand === 'chromium') {
+      // Continue to next as chromium is not a specific browser
+      continue
+    } else if (brand.includes('safari') && !brand.includes('chrome')) {
+      return {
+        name: Browser.Safari,
+        versionString: version,
+        version: parseVersion(version)
+      }
+    } else if (brand.includes('firefox')) {
+      return {
+        name: Browser.Firefox,
+        versionString: version,
+        version: parseVersion(version)
+      }
+    } else if (brand.includes('opera')) {
+      return {
+        name: Browser.Opera,
+        versionString: version,
+        version: parseVersion(version)
+      }
+    }
+  }
+
+  return null
+}
+
+function detectOSFromHints(hints: UAHintsData): RecognizedBrowserProperty<OS> | null {
+  if (!hints.platform) {
+    return null
+  }
+
+  const platform = hints.platform.toLowerCase()
+  const platformVersion = hints.platformVersion || ''
+
+  if (platform === 'windows') {
+    return {
+      name: OS.Windows,
+      versionString: platformVersion || 'Unknown',
+      version: platformVersion ? parseVersion(platformVersion) : []
+    }
+  } else if (platform === 'macos') {
+    return {
+      name: OS.MacOS,
+      versionString: platformVersion || 'Unknown',
+      version: platformVersion ? parseVersion(platformVersion) : []
+    }
+  } else if (platform === 'linux') {
+    return {
+      name: OS.Linux,
+      versionString: platformVersion || 'Unknown',
+      version: platformVersion ? parseVersion(platformVersion) : []
+    }
+  } else if (platform === 'android') {
+    return {
+      name: OS.Android,
+      versionString: platformVersion || 'Unknown',
+      version: platformVersion ? parseVersion(platformVersion) : []
+    }
+  } else if (platform === 'ios') {
+    return {
+      name: OS.iOS,
+      versionString: platformVersion || 'Unknown',
+      version: platformVersion ? parseVersion(platformVersion) : []
+    }
+  } else if (platform === 'chromeos') {
+    return {
+      name: OS.ChromeOS,
+      versionString: platformVersion || 'Unknown',
+      version: platformVersion ? parseVersion(platformVersion) : []
+    }
+  }
+
+  return null
+}
+
+function detectDeviceFromHints(hints: UAHintsData): RecognizedBrowserProperty<Device> | null {
+  if (hints.formFactors && hints.formFactors.length > 0) {
+    const formFactor = hints.formFactors[0].toLowerCase()
+    
+    if (formFactor === 'tablet') {
+      if (hints.platform?.toLowerCase() === 'ios') {
+        return {
+          name: Device.iPad,
+          versionString: 'Unknown',
+          version: []
+        }
+      }
+    } else if (formFactor === 'mobile') {
+      if (hints.platform?.toLowerCase() === 'ios') {
+        return {
+          name: Device.iPhone,
+          versionString: 'Unknown',
+          version: []
+        }
+      }
+    }
+  }
+
+  if (hints.model) {
+    const model = hints.model.toLowerCase()
+    
+    if (model.includes('iphone')) {
+      return {
+        name: Device.iPhone,
+        versionString: 'Unknown',
+        version: []
+      }
+    } else if (model.includes('ipad')) {
+      return {
+        name: Device.iPad,
+        versionString: 'Unknown',
+        version: []
+      }
+    } else if (model.includes('nexus')) {
+      return {
+        name: Device.Nexus,
+        versionString: 'Unknown',
+        version: []
+      }
+    } else if (model.includes('galaxy')) {
+      if (model.includes('nexus')) {
+        return {
+          name: Device.GalaxyNexus,
+          versionString: 'Unknown',
+          version: []
+        }
+      }
+      return {
+        name: Device.Galaxy,
+        versionString: 'Unknown',
+        version: []
+      }
+    }
+  }
+
+  return null
+}
+
 const isBrowser = typeof window !== 'undefined'
 
 export default class Sniffr {
@@ -162,6 +394,12 @@ export default class Sniffr {
     this.device = UnknownProperty
     this.browser = UnknownProperty
   }
+  
+  /**
+   * Synchronous sniffing using user agent string only.
+   * Useful for backward compatibility and server-side usage.
+   * For more accurate detection, use sniffHints() if in a browser.
+   */
   sniff(userAgentString?: string): this {
     const fallbackUserAgent = isBrowser ? navigator.userAgent : ''
     const userAgent = (userAgentString || fallbackUserAgent).toLowerCase()
@@ -169,6 +407,35 @@ export default class Sniffr {
     this.os = determineProperty(osMatchers, userAgent)
     this.device = determineProperty(deviceMatchers, userAgent)
     this.browser = determineProperty(browserMatchers, userAgent)
+    return this;
+  }
+
+  /**
+   * Sniffs browser, OS, and device using User-Agent Client Hints API if available,
+   * with fallback to user agent string.
+   * Requires User-Agent Client Hints API support in the browser.
+   * If hints are not available (e.g., Firefox, privacy settings), falls back to user agent string.
+   */
+  async sniffHints(userAgentString?: string): Promise<this> {
+    const fallbackUserAgent = isBrowser ? navigator.userAgent : ''
+    const userAgent = (userAgentString || fallbackUserAgent).toLowerCase()
+
+    let hintsData: UAHintsData | null = null
+    if (!userAgentString && (isBrowser || navigator?.userAgentData)) {
+      hintsData = await getUAHintsData()
+    }
+    if (hintsData) {
+      const browserFromHints = detectBrowserFromHints(hintsData)
+      const osFromHints = detectOSFromHints(hintsData)
+      const deviceFromHints = detectDeviceFromHints(hintsData)
+      this.browser = browserFromHints || determineProperty(browserMatchers, userAgent)
+      this.os = osFromHints || determineProperty(osMatchers, userAgent)
+      this.device = deviceFromHints || determineProperty(deviceMatchers, userAgent)
+    } else {
+      this.os = determineProperty(osMatchers, userAgent)
+      this.device = determineProperty(deviceMatchers, userAgent)
+      this.browser = determineProperty(browserMatchers, userAgent)
+    }
     return this;
   }
 }
@@ -180,20 +447,26 @@ export const RecognizedBrowser: RecognizedBrowser = {
 }
 
 if (isBrowser) {
-  const result = new Sniffr().sniff(navigator.userAgent)
-  RecognizedBrowser.os = result.os
-  RecognizedBrowser.device = result.device
-  RecognizedBrowser.browser = result.browser
+  const sniffer = new Sniffr()
+  sniffer.sniffHints().then(() => {
+    RecognizedBrowser.os = sniffer.os
+    RecognizedBrowser.device = sniffer.device
+    RecognizedBrowser.browser = sniffer.browser
+  }).catch(() => {
+    const fallbackSniffer = new Sniffr().sniff(navigator.userAgent)
+    RecognizedBrowser.os = fallbackSniffer.os
+    RecognizedBrowser.device = fallbackSniffer.device
+    RecognizedBrowser.browser = fallbackSniffer.browser
+  })
 }
 
-/*
- * Keeping compatibility with the scenarios where Sniffr is used as a standalone script on a page
- */
 declare global {
   interface Window {Sniffr: Sniffr}
 }
 
 if (isBrowser && typeof module == 'undefined') {
   window.Sniffr = new Sniffr()
-  window.Sniffr.sniff(navigator.userAgent);
+  window.Sniffr.sniffHints().catch(() => {
+    window.Sniffr.sniff(navigator.userAgent)
+  })
 }


### PR DESCRIPTION
* Use User-Agent Client Hints API if available, fallback to user agent string parsing if not available
* Keep backward compatibility, rather than changing the behavior of `sniff`, add another method `sniffHints` (asynchronous)